### PR TITLE
Restored test for check mode

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -1,4 +1,15 @@
 ---
+molecule:
+  test:
+    sequence:
+      - destroy
+      - syntax
+      - create
+      - converge
+      - idempotence
+      - check
+      - verify
+
 ansible:
   playbook: tests/test.yml
 


### PR DESCRIPTION
Molecule stopped running the test for check mode by default in version 1.16.1.