### PR TITLE
Switched to Ansible 2.2 check mode support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     url: '{{ postman_redis_url }}'
     method: HEAD
     follow_redirects: safe
-  always_run: yes
+  check_mode: no
   register: head_query
 
 - name: set latest version fact


### PR DESCRIPTION
Dropped `always_run: yes`, which will be removed in Ansible 2.4 in favour of `check_mode: no`, which was added in Ansible 2.2.