### PR TITLE
Removed upper Ansible limit from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Requirements
     * Minimum 2.2
         * Use version 1.1.1 of this role if you need Ansible 2.0/2.1 support
 
-    * Maximum 2.3 (currently using `always_run`, which is scheduled for removal
-      in 2.4)
-
 * Linux Distribution
 
     * Debian Family


### PR DESCRIPTION
Since the dependency on `always_run` has been removed there's currently no known upper Ansible version.