### PR TITLE
Removed unnecessary ca-certificates install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,13 +5,6 @@
     mode: 'u=rwx,go=rx'
     dest: '{{ postman_download_dir }}'
 
-- name: ensure ca-certificates installed (apt)
-  become: yes
-  apt:
-    name: ca-certificates
-    state: present
-  when: ansible_pkg_mgr == 'apt'
-
 - name: check for download version file
   stat:
     path: '{{ postman_download_version_path }}'


### PR DESCRIPTION
They can reasonably be expected to be present. This was only added for an earlier version of Molecule.