### PR TITLE
Migrated to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Role: Postman
 =====================
 
-[![Build Status](https://travis-ci.org/gantsign/ansible-role-postman.svg?branch=master)](https://travis-ci.org/gantsign/ansible-role-postman)
+[![Build Status](https://travis-ci.com/gantsign/ansible-role-postman.svg?branch=master)](https://travis-ci.com/gantsign/ansible-role-postman)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-gantsign.postman-blue.svg)](https://galaxy.ansible.com/gantsign/postman)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gantsign/ansible-role-postman/master/LICENSE)
 


### PR DESCRIPTION
`travis-ci.org` will be discontinued in December.